### PR TITLE
Added support for puppetserver and also redhat & debian os families.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,60 @@ A Puppet report handler for sending notifications of puppet runs to
            slack_botname        => 'puppet',
            slack_iconurl        => 'http://puppetlabs.com/wp-content/uploads/2010/12/PL_logo_vertical_RGB_lg.jpg',
            slack_puppet_reports => 'store,http,slack',
+           is_puppetmaster		=> true,
          }
   you might also want to set `slack_puppet_dir => '/etc/puppetlabs/puppet'` if you use puppet enterprise.
 
 1. Run the Puppet client and sync the report as a plugin
 
+### Class: `slack`
+The slack module sets up the puppetmaster or puppetserver for slack integration.
+
+**Parameters within `slack`:**
+
+#####`slack_url`
+
+The base url to your slack page. Required.
+Example: 'https://yourcompany.slack.com'
+
+#####`slack_token`
+
+The secret webhook. Required.
+
+#####`slack_channel`
+
+The channel where puppet messages will be sent.  
+Default: '#puppet'
+
+#####`slack_botname`
+
+The name of the slack bot
+Default: 'puppet'
+
+#####`slack_iconurl`
+
+The icon to show next to the puppet message.
+Default: 'http://puppetlabs.com/wp-content/uploads/2010/12/PL_logo_vertical_RGB_lg.jpg',
+
+#####`slack_puppet_reports`
+
+Manages the puppet report in the puppet.conf.  If left undef, this module will not modify the puppet.conf.
+Example: 'store,http,slack'
+
+#####`is_puppetmaster`
+
+The default is 'true' which means slack will manage the installation for a puppetmaster.
+Set to 'false' to use the [new PuppetServer](https://github.com/puppetlabs/puppet-server).
+
 ## Screenshot
 
 ![image](https://raw.githubusercontent.com/fsalum/puppet-slack/master/puppet-slack.png)
+
+## Tested
+
+The following operating systems were tested:
+* Centos 6.5
+* Ubuntu 14.04 
 
 ## Author
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,23 @@
+{
+  "author": "Felipe Salum",
+  "license": "Apache 2.0",
+  "name": "fsalum-slack",
+  "project_page": "https://github.com/fsalum/puppet-slack",
+  "requirements": [],
+  "source": "git://github.com/fsalum/puppet-slack.git",
+  "summary": "Slack.com integration for Puppet report processor",
+  "tags": [],
+  "version": "0.0.2",
+  "operatingsystem_support": [
+  	{ "operatingsystem":"Centos",
+	  "operatingsystemrelease":[ "5.0", "6.0" ] },
+  	{ "operatingsystem": "Ubuntu",
+  	  "operatingsystemrelease": [ "12.04", "14.04" ] }
+	],
+  "dependencies": [
+    {
+      "name": "conzar/check_run",
+      "version_requirement": ">= 0.2.3"
+    }
+  ]
+}


### PR DESCRIPTION
I have added support for the puppetserver.  It doesn't autodetect as I think that might be a bit too difficult.  Instead, a parameter is used for the class.  It defaults to installing puppetmaster.  Eventually, this can be changed to defaulting to the puppetserver once that is officially released.

I have also added OS support.  I have tested on Ubuntu and Centos so I am assuming it works on other flavours of those distros.  
