### PR TITLE
Update for URL-based webhooks, and message formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ A Puppet report handler for sending notifications of puppet runs to
 1. Add the class to the puppet master node:
 
          class { 'slack':
-           slack_url            => 'YOUR_SLACK_URL',
-           slack_token          => 'INCOMING_WEBHOOK_TOKEN',
+           slack_webhook        => 'INCOMING_WEBHOOK_URL',
            slack_channel        => '#puppet',
            slack_botname        => 'puppet',
            slack_iconurl        => 'http://puppetlabs.com/wp-content/uploads/2010/12/PL_logo_vertical_RGB_lg.jpg',
@@ -32,14 +31,9 @@ The slack module sets up the puppetmaster or puppetserver for slack integration.
 
 **Parameters within `slack`:**
 
-#####`slack_url`
+#####`slack_webhook`
 
-The base url to your slack page. Required.
-Example: 'https://yourcompany.slack.com'
-
-#####`slack_token`
-
-The secret webhook. Required.
+The secret webhook URL. Required.
 
 #####`slack_channel`
 

--- a/lib/puppet/reports/slack.rb
+++ b/lib/puppet/reports/slack.rb
@@ -1,5 +1,6 @@
 require 'puppet'
 require 'yaml'
+require 'json'
 require 'faraday'
 
 Puppet::Reports.register_report(:slack) do
@@ -11,23 +12,37 @@ Puppet::Reports.register_report(:slack) do
   @configfile = File.join(File.dirname(Puppet.settings[:config]), "slack.yaml")
   raise(Puppet::ParseError, "Slack report config file #{@configfile} not readable") unless File.exist?(@configfile)
   @config = YAML.load_file(@configfile)
-  SLACK_TOKEN = @config[:slack_token]
+  SLACK_WEBHOOK = @config[:slack_webhook]
   SLACK_CHANNEL = @config[:slack_channel]
   SLACK_BOTNAME = @config[:slack_botname]
   SLACK_ICONURL = @config[:slack_iconurl]
-  SLACK_URL = @config[:slack_url]
 
   def process
     if self.status == "failed" or self.status == "changed"
       Puppet.debug "Sending status for #{self.host} to Slack."
-      conn = Faraday.new(:url => "#{SLACK_URL}") do |faraday|
+      conn = Faraday.new(:url => "#{SLACK_WEBHOOK}") do |faraday|
           faraday.request  :url_encoded
           faraday.adapter  Faraday.default_adapter
       end
 
+      color = case self.status
+              when 'failed'
+                'danger'
+              when 'changed'
+                'good'
+              else
+                'warning'
+              end
+
+      message = { channel:  SLACK_CHANNEL,
+                  username: SLACK_BOTNAME,
+                  icon_url: SLACK_ICONURL,
+                  attachments: [{ fallback: "Puppet run for #{self.host} `#{self.status}` at #{Time.now.asctime}",
+                                  color: color,
+                                  text: "Puppet run for #{self.host} `#{self.status}` at #{Time.now.asctime}" }]}
+
       conn.post do |req|
-          req.url "/services/hooks/incoming-webhook?token=#{SLACK_TOKEN}"
-          req.body = "{\"channel\":\"#{SLACK_CHANNEL}\",\"username\":\"#{SLACK_BOTNAME}\", \"icon_url\":\"#{SLACK_ICONURL}\",\"text\":\"> Puppet run for #{self.host} `#{self.status}` at #{Time.now.asctime}\"}"
+        req.body = JSON.dump(message)
       end
     end
   end

--- a/lib/puppet/reports/slack.rb
+++ b/lib/puppet/reports/slack.rb
@@ -39,7 +39,8 @@ Puppet::Reports.register_report(:slack) do
                   icon_url: SLACK_ICONURL,
                   attachments: [{ fallback: "Puppet run for #{self.host} `#{self.status}` at #{Time.now.asctime}",
                                   color: color,
-                                  text: "Puppet run for #{self.host} `#{self.status}` at #{Time.now.asctime}" }]}
+                                  text: "Puppet run for #{self.host} `#{self.status}` at #{Time.now.asctime}",
+                                  mrkdwn_in: ["text"] }]}
 
       conn.post do |req|
         req.body = JSON.dump(message)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,6 @@
 # Report processor integration with Slack.com
 class slack (
-  $slack_token          = undef,
-  $slack_url            = undef,
+  $slack_webhook        = undef,
   $slack_iconurl        = 'http://puppetlabs.com/wp-content/uploads/2010/12/PL_logo_vertical_RGB_lg.png',
   $slack_channel        = '#puppet',
   $slack_botname        = 'puppet',
@@ -9,7 +8,7 @@ class slack (
   $slack_puppet_dir     = '/etc/puppet',
   $is_puppetmaster      = true,
 ) {
-  
+
   anchor {'slack::begin':}
 
   if $is_puppetmaster == true {

--- a/templates/slack.yaml.erb
+++ b/templates/slack.yaml.erb
@@ -1,6 +1,5 @@
 ---
-:slack_token: '<%= @slack_token %>'
+:slack_webhook: '<%= @slack_webhook %>'
 :slack_channel: '<%= @slack_channel %>'
 :slack_botname: '<%= @slack_botname %>'
 :slack_iconurl: '<%= @slack_iconurl %>'
-:slack_url: '<%= @slack_url %>'


### PR DESCRIPTION
Slack has updated their Incoming Webhooks integration to use a single URL in place of the token-argument previously used.

This PR replaces `slack_token` with `slack_webhook`. It also eliminates `slack_url`, as the team URL no longer factors into incoming webhooks.

Additionally, this PR makes use of Slack's Attachments API to color the bar next to the message as red or green, based on the success or failure of the Puppet run. It also uses the JSON standard library to convert a Ruby hash into JSON in lieu of the backslash-heavy string literal.
